### PR TITLE
Add PeerTube icon

### DIFF
--- a/build.js
+++ b/build.js
@@ -8,6 +8,7 @@ const noneSquareIconWidths = {
   lgtm: 19,
   now: 15,
   npm: 20,
+  peertube: 10,
   zeit: 15
 }
 

--- a/icons/peertube.svg
+++ b/icons/peertube.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17.454 24"><path d="M8.727 6.545v10.91L17.454 12M0 12v12l8.727-6.545M0 0v12l8.727-5.455" fill="#fff"/></svg>


### PR DESCRIPTION
This PR adds [PeerTube](https://joinpeertube.org) icon from [Simple Icons](https://simpleicons.org/?q=peertube) set.

### Checklist

* [x]  Optimize markup with [svgomg](https://jakearchibald.github.io/svgomg/)
* [x]  Preview with [badgen-icons.now.sh](https://badgen-icons.now.sh/)

### Preview

![image](https://user-images.githubusercontent.com/1170440/104139337-0ac30c80-53ab-11eb-866c-a14051e3e7ec.png)

---

Used by https://github.com/badgen/badgen.net/pull/476